### PR TITLE
Implement OpenAI provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# Saltcorn Large-Language-Model Plug-in (Scaffold)
+# Saltcorn Large-Language-Model Plug-in
 
-> **Status:** Scaffold only – every method intentionally throws *“Not implemented”*.
+> **Status:** OpenAI provider implemented; other providers remain scaffolds.
 
 This repository provides the framework for integrating Large Language Models
 with the Saltcorn low-code platform.  It aims to support:
@@ -19,7 +19,7 @@ src/plugin/
 │   └── Request.js          → Minimal `fetch` wrapper
 └── providers/
     ├── BaseProvider.js     → Abstract provider class
-    ├── OpenAIProvider.js   → Placeholder
+    ├── OpenAIProvider.js   → Official OpenAI implementation
     ├── OpenAICompatProvider.js
     ├── OlamaProvider.js
     ├── VertexProvider.js
@@ -33,7 +33,13 @@ src/plugin/
    yarn install
 
 3. Load the plug-in into Saltcorn (Admin → Plug-ins → “From folder”).
-4. All UI elements and actions will currently error – functionality is pending.
+4. Configure your OpenAI defaults via the plug-in settings screen. These values
+   include per-model parameters (e.g. `temperature`) and are used when a model is
+   not explicitly provided at call time.
+5. Run `node scripts/build-models.ts` to generate `models-openai.json` which
+   lists the parameters supported by each OpenAI model. Use this as a guide when
+   populating the JSON defaults.
+6. All remaining providers are still scaffolds and will throw when invoked.
 
 ## Licence
 

--- a/src/plugin/index.js
+++ b/src/plugin/index.js
@@ -1,7 +1,7 @@
 /**
  * Saltcorn Large-Language-Model Plug-in – Minimal scaffold
  *
- * • configuration_workflow → real Workflow instance (single debug checkbox)
+ * • configuration_workflow → Workflow allowing debug and model defaults
  * • actions                → function (returns empty object)
  * • No other hooks exported – Saltcorn supplies defaults
  *
@@ -30,6 +30,26 @@ function configuration_workflow() {
                 name : 'debug_enabled',
                 label: 'Verbose logging',
                 type : 'Bool',
+              },
+              {
+                name : 'openai_default_completion_model',
+                label: 'Default completion model',
+                type : 'String',
+              },
+              {
+                name : 'openai_default_embedding_model',
+                label: 'Default embedding model',
+                type : 'String',
+              },
+              {
+                name : 'openai_default_image_model',
+                label: 'Default image model',
+                type : 'String',
+              },
+              {
+                name : 'openai_model_defaults',
+                label: 'Model default parameters (JSON)',
+                type : 'String',
               },
             ],
           }),

--- a/src/plugin/providers/OpenAIProvider.js
+++ b/src/plugin/providers/OpenAIProvider.js
@@ -1,7 +1,8 @@
 /**
  * OpenAI provider (official REST API).
  *
- * Implementation deferred – uses BaseProvider scaffold only.
+ * Implements completion, embedding and image generation using the
+ * official OpenAI REST API.
  *
  * Author:   Troy Kelly <troy@team.production.city>
  * History:
@@ -18,22 +19,80 @@ class OpenAIProvider extends BaseProvider {
     super(cfg);
     this.baseUrl = cfg.baseUrl || 'https://api.openai.com';
     this.apiKey  = cfg.apiKey  || process.env.OPENAI_API_KEY;
+    this.defaultCompletionModel =
+      cfg.default_completion_model || 'gpt-3.5-turbo';
+    this.defaultEmbeddingModel =
+      cfg.default_embedding_model || 'text-embedding-ada-002';
+    this.defaultImageModel =
+      cfg.default_image_model || 'dall-e-3';
+
+    /* Optional JSON mapping of model → default parameters. */
+    try {
+      this.modelDefaults =
+        typeof cfg.model_defaults === 'string'
+          ? JSON.parse(cfg.model_defaults)
+          : cfg.model_defaults || {};
+    } catch {
+      this.modelDefaults = {};
+    }
   }
 
   /* ------------------------------------------------------------------ */
-  /* All methods currently throw – ready for future implementation.     */
+  /* Helper to attach headers                                           */
   /* ------------------------------------------------------------------ */
+
+  #headers() {
+    if (!this.apiKey) throw new Error('OpenAI API key not configured');
+    return {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${this.apiKey}`,
+    };
+  }
 
   async complete(model, prompt, opts = {}) { // eslint-disable-line no-unused-vars
-    throw new Error('OpenAIProvider.complete() not implemented.');
+    const mdl      = model || this.defaultCompletionModel;
+    const defaults = this.modelDefaults[mdl] || {};
+    const url      = `${this.baseUrl}/v1/chat/completions`;
+    const body = {
+      model: mdl,
+      messages: Array.isArray(prompt)
+        ? prompt
+        : [{ role: 'user', content: prompt }],
+      ...defaults,
+      ...opts,
+    };
+    this.log.debug('POST %s %o', url, body);
+    return request(url, {
+      method: 'POST',
+      headers: this.#headers(),
+      body: JSON.stringify(body),
+    });
   }
 
-  async embed(model, input) { // eslint-disable-line no-unused-vars
-    throw new Error('OpenAIProvider.embed() not implemented.');
+  async embed(model, input, opts = {}) { // eslint-disable-line no-unused-vars
+    const mdl      = model || this.defaultEmbeddingModel;
+    const defaults = this.modelDefaults[mdl] || {};
+    const url      = `${this.baseUrl}/v1/embeddings`;
+    const body = { model: mdl, input, ...defaults, ...opts };
+    this.log.debug('POST %s %o', url, body);
+    return request(url, {
+      method: 'POST',
+      headers: this.#headers(),
+      body: JSON.stringify(body),
+    });
   }
 
   async generateImage(model, prompt, opts = {}) { // eslint-disable-line no-unused-vars
-    throw new Error('OpenAIProvider.generateImage() not implemented.');
+    const mdl      = model || this.defaultImageModel;
+    const defaults = this.modelDefaults[mdl] || {};
+    const url      = `${this.baseUrl}/v1/images/generations`;
+    const body = { model: mdl, prompt, ...defaults, ...opts };
+    this.log.debug('POST %s %o', url, body);
+    return request(url, {
+      method: 'POST',
+      headers: this.#headers(),
+      body: JSON.stringify(body),
+    });
   }
 }
 


### PR DESCRIPTION
## Summary
- flesh out the OpenAI provider to actually call the OpenAI REST API
- allow default model configuration in the plugin workflow
- document the updated provider and configuration steps
- add per-model parameters that can be overridden when calling

## Testing
- `node -c src/plugin/providers/OpenAIProvider.js`
- `node -c src/plugin/index.js`
